### PR TITLE
fix: updates solution to use AMAZON_COGNITO_USER_POOLS to authenticate to AppSync

### DIFF
--- a/broadcast-monitoring-ui/amplify/backend/backend-config.json
+++ b/broadcast-monitoring-ui/amplify/backend/backend-config.json
@@ -8,11 +8,7 @@
         "authConfig": {
           "additionalAuthenticationProviders": [],
           "defaultAuthentication": {
-            "authenticationType": "API_KEY",
-            "apiKeyConfig": {
-              "description": "latest",
-              "apiKeyExpirationDays": "365"
-            }
+            "authenticationType": "AMAZON_COGNITO_USER_POOLS"
           }
         }
       }

--- a/broadcast-monitoring-ui/src/main.js
+++ b/broadcast-monitoring-ui/src/main.js
@@ -5,9 +5,9 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import '@aws-amplify/ui-vue'
-import Amplify from 'aws-amplify'
+import Amplify, { Auth } from 'aws-amplify'
 import VueApollo from 'vue-apollo'
-import AWSAppSyncClient from 'aws-appsync'
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync'
 import awsconfig from './aws-exports'
 import store from './store/store'
 import Buefy from 'buefy'
@@ -24,8 +24,8 @@ const appSyncConfig = {
   url: awsconfig.aws_appsync_graphqlEndpoint,
   region: awsconfig.aws_appsync_region,
   auth: {
-    type: 'API_KEY',
-    apiKey: awsconfig.aws_appsync_apiKey
+    type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+    jwtToken: (await Auth.currentSession()).getAccessToken().getJwtToken()
   }
 }
 const options = {


### PR DESCRIPTION
This PR updates the UI to use [AMAZON_COGNITO_USER_POOLS](https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#amazon-cognito-user-pools-authorization) authentication to access the AppSync GraphQL endpoint. Previously the `API_KEY` method was being used. When built and minified, this could result in the `API_KEY` being exposed in the frontend web app source.

To prevent this issue from occurring, we have changed the AppSync auth method to use COGNITO_USER_POOL authentication as detailed [here](https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/5#issuecomment-359076595)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
